### PR TITLE
:bug: Fix bug with Start Earning not opening modal

### DIFF
--- a/src/components/my-account/AccountBalance.tsx
+++ b/src/components/my-account/AccountBalance.tsx
@@ -299,6 +299,7 @@ const AccountBalance: React.FC<Props> = (props: Props) => {
               })}
             </RebassTbody>
           </RebassTable>
+          <LoginModal isOpen={loginModalIsOpen} onRequestClose={closeLoginModal} redirect={props.redirect} />
         </Card>
       )}
     </>


### PR DESCRIPTION
The issue was related to the LoginModal component not being rendered in the context of the new designs table
